### PR TITLE
[fixed] don't try to list items in ignored disks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Fixed
 - updated README.md to reflect the naming change from _ignore_buckets_ to _ignore_disks
+- don't try to list items in ignored disks to avoid errors
 
 ## 1.3.0 - 2022-07-05
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Fixed
-- updated README.md to reflect the naming change from _ignore_buckets_ to _ignore_disks
+- updated README.md to reflect the naming change from _ignore_buckets_ to _ignore_disks_
 - don't try to list items in ignored disks to avoid errors
 
 ## 1.3.0 - 2022-07-05


### PR DESCRIPTION
Will avoid errors like
```
WARN[0000] Unable to list items in S3 bucket "{\n  CreationDate: 2019-09-17 07:18:48 +0000 UTC,\n  Name: \"XXXXXXXXX-chartmuseum\"\n}", AccessDenied: Access Denied
        status code: 403, request id: 87QHYMJJ6WVKM7HN, host id: d7cJysOPKQtfNm8RWMcSbTcskH42PqxF9cDKgweDk5J1krI4oA0ofnrY7YixgcQ52Fs8zsctl7k=; won't use it as disk 
```